### PR TITLE
Fix plugin meta info

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,8 @@
 <idea-plugin>
 	<name>MoveTab</name>
+	<id>com.mikejhill.intellij.movetab</id>
 	<vendor email="mike@mikejhill.com">Mike Hill</vendor>
+	<icon>pluginIcon.svg</icon>
 
 	<description>
 		<![CDATA[


### PR DESCRIPTION
## Summary
- include a plugin id in plugin.xml
- add missing plugin icon
- fix indentation to match tabs used by the rest of the file

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841c5897cb0832c8e6e154d69c4c7cb