### PR TITLE
Add AGENTS file to discourage Gradle use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS Instructions
+
+* Gradle commands are time-consuming because they download large dependencies. Avoid running any Gradle commands (such as `gradle` or `./gradlew`) in this repository.
+* There are no mandatory programmatic checks for this repository.
+


### PR DESCRIPTION
## Summary
- add root AGENTS instructions advising against running Gradle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684243f42c0c832c833cce27a756d2ef