### PR TITLE
Add concurrency to GitHub workflows

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -4,6 +4,10 @@ on:
     push:
         tags: 'v[0-9]+.[0-9]+.[0-9]+-?*'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     build:
         name: Build, Verify, and Publish Plugin

--- a/.github/workflows/verify-plugin.yml
+++ b/.github/workflows/verify-plugin.yml
@@ -7,6 +7,10 @@ on:
     pull_request:
         branches: '*'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     build:
         name: Build and Verify Plugin


### PR DESCRIPTION
## Summary
- prevent duplicate CI runs on rapid pushes by adding `concurrency` groups

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68424a03877c832cbb2593ec8f637946