### PR TITLE
Add CodeQL configuration

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "MoveTab CodeQL"
+# Ensure CodeQL uses Java 21 so Gradle plugins like the Foojay resolver work.
+build:
+  java:
+    version: "21"
+  command: ./gradlew --no-daemon :move-tab-plugin:assemble

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 * There are no mandatory programmatic checks for this repository.
 * Use common prefixes across all modules within multi-module projects. The prefix for this project is `move-tab`; modules should be named using this prefix (e.g. `move-tab-plugin`).
 * `AGENTS.md` should be continually updated when new or helpful standards or conventions are brought up during interactions.
+* Code scanning with CodeQL requires Java 21. A CodeQL configuration file (`.github/codeql/codeql-config.yml`) sets this version, so keep it in sync with the build.


### PR DESCRIPTION
## Summary
- add a CodeQL config so analysis uses Java 21
- note the Java 21 requirement in `AGENTS.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68426a3a3e80832c91fa4f188d955c41