### PR TITLE
Handle missing predicted version in summary

### DIFF
--- a/.github/workflows/verify-plugin.yml
+++ b/.github/workflows/verify-plugin.yml
@@ -33,12 +33,26 @@ jobs:
                     ./gradlew --no-daemon :move-tab-plugin:verifyPlugin
             -   name: Predict Next Version
                 id: semrel
-                uses: go-semantic-release/action@v1
-                with:
-                    github-token: ${{ secrets.GITHUB_TOKEN }}
-                    dry: true
+                shell: bash
+                run: |
+                    curl -L -o semrel https://registry.go-semantic-release.xyz/downloads/linux/amd64/semantic-release
+                    chmod +x semrel
+                    ./semrel --version-file --changelog .generated-go-semantic-release-changelog.md --token ${{ secrets.GITHUB_TOKEN }} --dry --allow-no-changes 2>&1 | tee semrel.log
+                    if [ -f .version-unreleased ]; then
+                        version=$(cat .version-unreleased)
+                        rm .version-unreleased
+                    else
+                        version=""
+                    fi
+                    previous=$(grep -m1 -oE 'found version: [^ ]+' semrel.log | awk '{print $3}')
+                    echo "version=$version" >> "$GITHUB_OUTPUT"
+                    echo "previous=$previous" >> "$GITHUB_OUTPUT"
             -   name: Show Predicted Version
                 run: |
                     echo "### Predicted Release Version" >> "$GITHUB_STEP_SUMMARY"
                     echo "" >> "$GITHUB_STEP_SUMMARY"
-                    echo "Next release version if created from this commit: **${{ steps.semrel.outputs.version }}**" >> "$GITHUB_STEP_SUMMARY"
+                    version="${{ steps.semrel.outputs.version }}"
+                    if [ -z "$version" ]; then
+                        version="${{ steps.semrel.outputs.previous }} (insufficient changes for new version)"
+                    fi
+                    echo "Next release version if created from this commit: **$version**" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-plugin.yml
+++ b/.github/workflows/verify-plugin.yml
@@ -37,7 +37,7 @@ jobs:
                 run: |
                     curl -L -o semrel https://registry.go-semantic-release.xyz/downloads/linux/amd64/semantic-release
                     chmod +x semrel
-                    ./semrel --version-file --changelog .generated-go-semantic-release-changelog.md --token ${{ secrets.GITHUB_TOKEN }} --dry --allow-no-changes 2>&1 | tee semrel.log
+                    ./semrel --version-file --changelog .generated-go-semantic-release-changelog.md --token ${{ secrets.GITHUB_TOKEN }} --dry --allow-no-changes --no-ci 2>&1 | tee semrel.log
                     if [ -f .version-unreleased ]; then
                         version=$(cat .version-unreleased)
                         rm .version-unreleased

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 * There are no mandatory programmatic checks for this repository.
 * Use common prefixes across all modules within multi-module projects. The prefix for this project is `move-tab`; modules should be named using this prefix (e.g. `move-tab-plugin`).
 * `AGENTS.md` should be continually updated when new or helpful standards or conventions are brought up during interactions.
+* In pull request workflows, run `go-semantic-release` with `--no-ci` so it can execute without failing CI condition checks.
 
 ## Commit Messages
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 * There are no mandatory programmatic checks for this repository.
 * Use common prefixes across all modules within multi-module projects. The prefix for this project is `move-tab`; modules should be named using this prefix (e.g. `move-tab-plugin`).
 * `AGENTS.md` should be continually updated when new or helpful standards or conventions are brought up during interactions.
-* In pull request workflows, run `go-semantic-release` with `--no-ci` so it can execute without failing CI condition checks.
+* In pull request workflows, run `go-semantic-release` with `--no-ci` so it can execute without failing the CI condition checks.
 
 ## Commit Messages
 


### PR DESCRIPTION
## Summary
- show current tag if predicted version is empty in summary step

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68427338b3e8832c9513d06bb4d5f9c9