### PR TITLE
Add actions to move tab to start or end

### DIFF
--- a/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTab.kt
+++ b/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTab.kt
@@ -52,24 +52,21 @@ abstract class MoveTab : AnAction(), DumbAware {
         currentTab: TabInfo,
         direction: MoveTabDirection
     ): List<TabInfo> {
-        // Get new tab index
         val origIndex = origTabList.indexOf(currentTab)
-        val targetIndex = origIndex + when (direction) {
-            MoveTabDirection.LEFT -> -1
-            MoveTabDirection.RIGHT -> 1
-        }
-        val newIndex = when {
-            targetIndex < 0 -> origTabList.size - 1
-            targetIndex >= origTabList.size -> 0
-            else -> targetIndex
+        val lastIndex = origTabList.lastIndex
+
+        val newIndex = when (direction) {
+            MoveTabDirection.LEFT -> if (origIndex == 0) lastIndex else origIndex - 1
+            MoveTabDirection.RIGHT -> if (origIndex == lastIndex) 0 else origIndex + 1
+            MoveTabDirection.START -> 0
+            MoveTabDirection.END -> lastIndex
         }
 
-        // Get mutated list
         return origTabList.toMutableList()
             .apply { removeAt(origIndex) }
             .apply { add(newIndex, currentTab) }
             .toList()
     }
 
-    enum class MoveTabDirection { LEFT, RIGHT }
+    enum class MoveTabDirection { LEFT, RIGHT, START, END }
 }

--- a/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabToEnd.kt
+++ b/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabToEnd.kt
@@ -1,0 +1,9 @@
+package com.mikejhill.intellij.movetab.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class MoveTabToEnd : MoveTab() {
+    override fun actionPerformed(event: AnActionEvent) {
+        super.perform(event, MoveTabDirection.END)
+    }
+}

--- a/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabToStart.kt
+++ b/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabToStart.kt
@@ -1,0 +1,9 @@
+package com.mikejhill.intellij.movetab.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class MoveTabToStart : MoveTab() {
+    override fun actionPerformed(event: AnActionEvent) {
+        super.perform(event, MoveTabDirection.START)
+    }
+}

--- a/move-tab-plugin/src/main/resources/META-INF/plugin.xml
+++ b/move-tab-plugin/src/main/resources/META-INF/plugin.xml
@@ -10,14 +10,16 @@
 				This plugin adds keyboard shortcuts for reordering IDE tabs. This is based off of the similar, but now defunct, plugin of a similar name by <a href="https://plugins.jetbrains.com/plugin/8443-a-move-tab-left-and-right-using-the-keyboard-plugin--by-momomo-com">momomo.com</a>.
 			</p>
 			<p>
-				Usage (default keyboard shortcuts):
-				<ul>
-					<li>Ctrl+Shift+Page Up: Move the current tab to the left.</li>
-					<li>Ctrl+Shift+Page Down: Move the current tab to the right.</li>
-				</ul>
-			</p>
-		]]>
-	</description>
+                                Usage (default keyboard shortcuts):
+                                <ul>
+                                        <li>Ctrl+Shift+Page Up: Move the current tab to the left.</li>
+                                        <li>Ctrl+Shift+Page Down: Move the current tab to the right.</li>
+                                        <li>Ctrl+Shift+Home: Move the current tab to the start.</li>
+                                        <li>Ctrl+Shift+End: Move the current tab to the end.</li>
+                                </ul>
+                        </p>
+                ]]>
+        </description>
 
 	<!-- See https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges -->
 	<depends>com.intellij.modules.platform</depends>
@@ -26,10 +28,16 @@
 		<action id="com.mikejhill.intellij.movetab.actions.MoveTabLeft" class="com.mikejhill.intellij.movetab.actions.MoveTabLeft" text="Move Tab Left">
 			<keyboard-shortcut keymap="$default" first-keystroke="ctrl shift PAGE_UP" />
 		</action>
-		<action id="com.mikejhill.intellij.movetab.actions.MoveTabRight" class="com.mikejhill.intellij.movetab.actions.MoveTabRight" text="Move Tab Right">
-			<keyboard-shortcut keymap="$default" first-keystroke="ctrl shift PAGE_DOWN" />
-		</action>
-	</actions>
+                <action id="com.mikejhill.intellij.movetab.actions.MoveTabRight" class="com.mikejhill.intellij.movetab.actions.MoveTabRight" text="Move Tab Right">
+                        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift PAGE_DOWN" />
+                </action>
+                <action id="com.mikejhill.intellij.movetab.actions.MoveTabToStart" class="com.mikejhill.intellij.movetab.actions.MoveTabToStart" text="Move Tab To Start">
+                        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift HOME" />
+                </action>
+                <action id="com.mikejhill.intellij.movetab.actions.MoveTabToEnd" class="com.mikejhill.intellij.movetab.actions.MoveTabToEnd" text="Move Tab To End">
+                        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift END" />
+                </action>
+        </actions>
 
 	<extensions defaultExtensionNs="com.intellij" />
 

--- a/move-tab-plugin/src/test/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabTest.kt
+++ b/move-tab-plugin/src/test/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabTest.kt
@@ -213,6 +213,126 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 5, 1, 2, 3, 4)
     }
 
+    @Test
+    fun `test_move_to_start_with_0_tabs`() {
+        prepareTabList(0, null)
+        validateTabList(tabList)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList)
+    }
+
+    @Test
+    fun `test_move_to_start_with_1_tab`() {
+        prepareTabList(1, 0)
+        validateTabList(tabList, 1)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1)
+    }
+
+    @Test
+    fun `test_move_to_start_with_2_tabs`() {
+        prepareTabList(2, 0)
+        validateTabList(tabList, 1, 2)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2)
+    }
+
+    @Test
+    fun `test_move_to_start_with_5_tabs`() {
+        prepareTabList(5, 0)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+    }
+
+    @Test
+    fun `test_move_to_start_with_5_tabs_no_selection`() {
+        prepareTabList(5, null)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+    }
+
+    @Test
+    fun `test_move_to_start_with_5_tabs_select_tab_5`() {
+        prepareTabList(5, 4)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 5, 1, 2, 3, 4)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 5, 1, 2, 3, 4)
+    }
+
+    @Test
+    fun `test_move_to_end_with_0_tabs`() {
+        prepareTabList(0, null)
+        validateTabList(tabList)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList)
+    }
+
+    @Test
+    fun `test_move_to_end_with_1_tab`() {
+        prepareTabList(1, 0)
+        validateTabList(tabList, 1)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1)
+    }
+
+    @Test
+    fun `test_move_to_end_with_2_tabs`() {
+        prepareTabList(2, 0)
+        validateTabList(tabList, 1, 2)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 2, 1)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 2, 1)
+    }
+
+    @Test
+    fun `test_move_to_end_with_5_tabs`() {
+        prepareTabList(5, 0)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 2, 3, 4, 5, 1)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 2, 3, 4, 5, 1)
+    }
+
+    @Test
+    fun `test_move_to_end_with_5_tabs_no_selection`() {
+        prepareTabList(5, null)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+    }
+
+    @Test
+    fun `test_move_to_end_with_5_tabs_select_tab_5`() {
+        prepareTabList(5, 4)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+    }
+
     private fun prepareTabList(count: Int, selectedIndex: Int?) {
         tabList = (1..count).map { tabNum ->
             val tabName = "${tabNum}"


### PR DESCRIPTION
## Summary
- support moving tabs directly to the first or last position
- register MoveTabToStart and MoveTabToEnd actions with keyboard shortcuts
- test new behaviours for moving tabs

## Testing
- `./gradlew --no-daemon test` *(fails: Gradle IntelliJ Plugin 1.x does not support building plugins against the IntelliJ Platform 2024.2+)*
- `go-semantic-release --no-ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427ba77f8c832cbf814667410ced7e