### PR TITLE
Fix CodeQL check by restoring config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "MoveTab CodeQL"
+# Ensure CodeQL uses Java 21 so Gradle plugins like the Foojay resolver work.
+build:
+  java:
+    version: "21"
+  command: ./gradlew --no-daemon :move-tab-plugin:assemble

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 * Use common prefixes across all modules within multi-module projects. The prefix for this project is `move-tab`; modules should be named using this prefix (e.g. `move-tab-plugin`).
 * `AGENTS.md` should be continually updated when new or helpful standards or conventions are brought up during interactions.
 * Follow `.editorconfig` conventions when adding or modifying files.
+* Code scanning with CodeQL requires Java 21. A CodeQL configuration file (`.github/codeql/codeql-config.yml`) sets this version, so keep it in sync with the build.
 
 ## Commit Messages
 


### PR DESCRIPTION
## Summary
- restore CodeQL configuration so default scan can run
- note CodeQL requirements in `AGENTS.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68446d4e82fc832c9fe2dc84552129b3