### PR TITLE
Add actions to move tab to start or end

### DIFF
--- a/move-tab-plugin/build.gradle.kts
+++ b/move-tab-plugin/build.gradle.kts
@@ -45,16 +45,12 @@ tasks.withType<RunIdeTask> {
     jvmArgs("-Xms4g", "-Xmx4g", "-Dcom.sun.management.jmxremote")
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
 
 fun getPropertyValue(name: String): String? {
     return if (project.extra.has(name)) project.extra[name]?.toString() else System.getenv(name)
 }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter:5.13.0")
     testImplementation("io.mockk:mockk:1.14.2")
     // Required for BasePlatformTestCase (see FAQ about JUnit5 tests referring to JUnit4
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-faq.html#junit5-test-framework-refers-to-junit4)

--- a/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTab.kt
+++ b/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTab.kt
@@ -52,24 +52,21 @@ abstract class MoveTab : AnAction(), DumbAware {
         currentTab: TabInfo,
         direction: MoveTabDirection
     ): List<TabInfo> {
-        // Get new tab index
         val origIndex = origTabList.indexOf(currentTab)
-        val targetIndex = origIndex + when (direction) {
-            MoveTabDirection.LEFT -> -1
-            MoveTabDirection.RIGHT -> 1
-        }
-        val newIndex = when {
-            targetIndex < 0 -> origTabList.size - 1
-            targetIndex >= origTabList.size -> 0
-            else -> targetIndex
+        val lastIndex = origTabList.lastIndex
+
+        val newIndex = when (direction) {
+            MoveTabDirection.LEFT -> if (origIndex == 0) lastIndex else origIndex - 1
+            MoveTabDirection.RIGHT -> if (origIndex == lastIndex) 0 else origIndex + 1
+            MoveTabDirection.START -> 0
+            MoveTabDirection.END -> lastIndex
         }
 
-        // Get mutated list
         return origTabList.toMutableList()
             .apply { removeAt(origIndex) }
             .apply { add(newIndex, currentTab) }
             .toList()
     }
 
-    enum class MoveTabDirection { LEFT, RIGHT }
+    enum class MoveTabDirection { LEFT, RIGHT, START, END }
 }

--- a/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabToEnd.kt
+++ b/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabToEnd.kt
@@ -1,0 +1,9 @@
+package com.mikejhill.intellij.movetab.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class MoveTabToEnd : MoveTab() {
+    override fun actionPerformed(event: AnActionEvent) {
+        super.perform(event, MoveTabDirection.END)
+    }
+}

--- a/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabToStart.kt
+++ b/move-tab-plugin/src/main/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabToStart.kt
@@ -1,0 +1,9 @@
+package com.mikejhill.intellij.movetab.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class MoveTabToStart : MoveTab() {
+    override fun actionPerformed(event: AnActionEvent) {
+        super.perform(event, MoveTabDirection.START)
+    }
+}

--- a/move-tab-plugin/src/main/resources/META-INF/plugin.xml
+++ b/move-tab-plugin/src/main/resources/META-INF/plugin.xml
@@ -10,14 +10,14 @@
 				This plugin adds keyboard shortcuts for reordering IDE tabs. This is based off of the similar, but now defunct, plugin of a similar name by <a href="https://plugins.jetbrains.com/plugin/8443-a-move-tab-left-and-right-using-the-keyboard-plugin--by-momomo-com">momomo.com</a>.
 			</p>
 			<p>
-				Usage (default keyboard shortcuts):
-				<ul>
-					<li>Ctrl+Shift+Page Up: Move the current tab to the left.</li>
-					<li>Ctrl+Shift+Page Down: Move the current tab to the right.</li>
-				</ul>
-			</p>
-		]]>
-	</description>
+                                Usage (default keyboard shortcuts):
+                                <ul>
+                                        <li>Ctrl+Shift+Page Up: Move the current tab to the left.</li>
+                                        <li>Ctrl+Shift+Page Down: Move the current tab to the right.</li>
+                                </ul>
+                        </p>
+                ]]>
+        </description>
 
 	<!-- See https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges -->
 	<depends>com.intellij.modules.platform</depends>
@@ -26,8 +26,12 @@
 		<action id="com.mikejhill.intellij.movetab.actions.MoveTabLeft" class="com.mikejhill.intellij.movetab.actions.MoveTabLeft" text="Move Tab Left">
 			<keyboard-shortcut keymap="$default" first-keystroke="ctrl shift PAGE_UP" />
 		</action>
-		<action id="com.mikejhill.intellij.movetab.actions.MoveTabRight" class="com.mikejhill.intellij.movetab.actions.MoveTabRight" text="Move Tab Right">
-			<keyboard-shortcut keymap="$default" first-keystroke="ctrl shift PAGE_DOWN" />
+                <action id="com.mikejhill.intellij.movetab.actions.MoveTabRight" class="com.mikejhill.intellij.movetab.actions.MoveTabRight" text="Move Tab Right">
+                        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift PAGE_DOWN" />
+                </action>
+		<action id="com.mikejhill.intellij.movetab.actions.MoveTabToStart" class="com.mikejhill.intellij.movetab.actions.MoveTabToStart" text="Move Tab To Start">
+		</action>
+		<action id="com.mikejhill.intellij.movetab.actions.MoveTabToEnd" class="com.mikejhill.intellij.movetab.actions.MoveTabToEnd" text="Move Tab To End">
 		</action>
 	</actions>
 

--- a/move-tab-plugin/src/test/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabTest.kt
+++ b/move-tab-plugin/src/test/kotlin/com/mikejhill/intellij/movetab/actions/MoveTabTest.kt
@@ -13,17 +13,10 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.impl.annotations.MockK
-import io.mockk.junit5.MockKExtension
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
 import java.awt.Component
 import javax.swing.JLabel
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(MockKExtension::class)
 class MoveTabTest : BasePlatformTestCase() {
 
     // Stateful test properties
@@ -38,8 +31,8 @@ class MoveTabTest : BasePlatformTestCase() {
     @MockK lateinit var tabComponentMock: JBEditorTabs
     @MockK lateinit var actionEventMock: AnActionEvent
 
-    @BeforeAll
-    fun setup() {
+    override fun setUp() {
+        super.setUp()
         MockKAnnotations.init(this)
         prepareMocks()
     }
@@ -57,8 +50,7 @@ class MoveTabTest : BasePlatformTestCase() {
         every { actionEventMock.project } returns projectMock
     }
 
-    @Test
-    fun `test_move_left_with_0_tabs`() {
+    fun testMoveLeftWith0Tabs() {
         prepareTabList(0, null)
         validateTabList(tabList)
         MoveTabLeft().actionPerformed(actionEventMock)
@@ -67,8 +59,7 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList)
     }
 
-    @Test
-    fun `test_move_left_with_1_tab`() {
+    fun testMoveLeftWith1Tab() {
         prepareTabList(1, 0)
         validateTabList(tabList, 1)
         MoveTabLeft().actionPerformed(actionEventMock)
@@ -77,20 +68,18 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 1)
     }
 
-    @Test
-    fun `test_move_left_with_2_tabs`() {
+    fun testMoveLeftWith2Tabs() {
         prepareTabList(2, 0)
         validateTabList(tabList, 1, 2)
         MoveTabLeft().actionPerformed(actionEventMock)
-        Assertions.assertEquals(currentTab, tabComponentMock.selectedInfo)
+        assertEquals(currentTab, tabComponentMock.selectedInfo)
         validateTabList(tabList, 2, 1)
         MoveTabLeft().actionPerformed(actionEventMock)
-        Assertions.assertEquals(currentTab, tabComponentMock.selectedInfo)
+        assertEquals(currentTab, tabComponentMock.selectedInfo)
         validateTabList(tabList, 1, 2)
     }
 
-    @Test
-    fun `test_move_left_with_5_tabs`() {
+    fun testMoveLeftWith5Tabs() {
         prepareTabList(5, 0)
         validateTabList(tabList, 1, 2, 3, 4, 5)
         MoveTabLeft().actionPerformed(actionEventMock)
@@ -107,8 +96,7 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 2, 3, 4, 5, 1)
     }
 
-    @Test
-    fun `test_move_left_with_5_tabs_no_selection`() {
+    fun testMoveLeftWith5TabsNoSelection() {
         prepareTabList(5, null)
         validateTabList(tabList, 1, 2, 3, 4, 5)
         MoveTabLeft().actionPerformed(actionEventMock)
@@ -117,8 +105,7 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 1, 2, 3, 4, 5)
     }
 
-    @Test
-    fun `test_move_left_with_5_tabs_select_tab_5`() {
+    fun testMoveLeftWith5TabsSelectTab5() {
         prepareTabList(5, 4)
         validateTabList(tabList, 1, 2, 3, 4, 5)
         MoveTabLeft().actionPerformed(actionEventMock)
@@ -135,8 +122,7 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 1, 2, 3, 5, 4)
     }
 
-    @Test
-    fun `test_move_right_with_0_tabs`() {
+    fun testMoveRightWith0Tabs() {
         prepareTabList(0, null)
         validateTabList(tabList)
         MoveTabRight().actionPerformed(actionEventMock)
@@ -145,8 +131,7 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList)
     }
 
-    @Test
-    fun `test_move_right_with_1_tab`() {
+    fun testMoveRightWith1Tab() {
         prepareTabList(1, 0)
         validateTabList(tabList, 1)
         MoveTabRight().actionPerformed(actionEventMock)
@@ -155,20 +140,18 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 1)
     }
 
-    @Test
-    fun `test_move_right_with_2_tabs`() {
+    fun testMoveRightWith2Tabs() {
         prepareTabList(2, 0)
         validateTabList(tabList, 1, 2)
         MoveTabRight().actionPerformed(actionEventMock)
-        Assertions.assertEquals(currentTab, tabComponentMock.selectedInfo)
+        assertEquals(currentTab, tabComponentMock.selectedInfo)
         validateTabList(tabList, 2, 1)
         MoveTabRight().actionPerformed(actionEventMock)
-        Assertions.assertEquals(currentTab, tabComponentMock.selectedInfo)
+        assertEquals(currentTab, tabComponentMock.selectedInfo)
         validateTabList(tabList, 1, 2)
     }
 
-    @Test
-    fun `test_move_right_with_5_tabs`() {
+    fun testMoveRightWith5Tabs() {
         prepareTabList(5, 0)
         validateTabList(tabList, 1, 2, 3, 4, 5)
         MoveTabRight().actionPerformed(actionEventMock)
@@ -185,8 +168,7 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 2, 1, 3, 4, 5)
     }
 
-    @Test
-    fun `test_move_right_with_5_tabs_no_selection`() {
+    fun testMoveRightWith5TabsNoSelection() {
         prepareTabList(5, null)
         validateTabList(tabList, 1, 2, 3, 4, 5)
         MoveTabRight().actionPerformed(actionEventMock)
@@ -195,8 +177,7 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 1, 2, 3, 4, 5)
     }
 
-    @Test
-    fun `test_move_right_with_5_tabs_select_tab_5`() {
+    fun testMoveRightWith5TabsSelectTab5() {
         prepareTabList(5, 4)
         validateTabList(tabList, 1, 2, 3, 4, 5)
         MoveTabRight().actionPerformed(actionEventMock)
@@ -211,6 +192,114 @@ class MoveTabTest : BasePlatformTestCase() {
         validateTabList(tabList, 1, 2, 3, 4, 5)
         MoveTabRight().actionPerformed(actionEventMock)
         validateTabList(tabList, 5, 1, 2, 3, 4)
+    }
+
+    fun testMoveToStartWith0Tabs() {
+        prepareTabList(0, null)
+        validateTabList(tabList)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList)
+    }
+
+    fun testMoveToStartWith1Tab() {
+        prepareTabList(1, 0)
+        validateTabList(tabList, 1)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1)
+    }
+
+    fun testMoveToStartWith2Tabs() {
+        prepareTabList(2, 0)
+        validateTabList(tabList, 1, 2)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2)
+    }
+
+    fun testMoveToStartWith5Tabs() {
+        prepareTabList(5, 0)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+    }
+
+    fun testMoveToStartWith5TabsNoSelection() {
+        prepareTabList(5, null)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+    }
+
+    fun testMoveToStartWith5TabsSelectTab5() {
+        prepareTabList(5, 4)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 5, 1, 2, 3, 4)
+        MoveTabToStart().actionPerformed(actionEventMock)
+        validateTabList(tabList, 5, 1, 2, 3, 4)
+    }
+
+    fun testMoveToEndWith0Tabs() {
+        prepareTabList(0, null)
+        validateTabList(tabList)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList)
+    }
+
+    fun testMoveToEndWith1Tab() {
+        prepareTabList(1, 0)
+        validateTabList(tabList, 1)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1)
+    }
+
+    fun testMoveToEndWith2Tabs() {
+        prepareTabList(2, 0)
+        validateTabList(tabList, 1, 2)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 2, 1)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 2, 1)
+    }
+
+    fun testMoveToEndWith5Tabs() {
+        prepareTabList(5, 0)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 2, 3, 4, 5, 1)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 2, 3, 4, 5, 1)
+    }
+
+    fun testMoveToEndWith5TabsNoSelection() {
+        prepareTabList(5, null)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+    }
+
+    fun testMoveToEndWith5TabsSelectTab5() {
+        prepareTabList(5, 4)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
+        MoveTabToEnd().actionPerformed(actionEventMock)
+        validateTabList(tabList, 1, 2, 3, 4, 5)
     }
 
     private fun prepareTabList(count: Int, selectedIndex: Int?) {
@@ -226,7 +315,7 @@ class MoveTabTest : BasePlatformTestCase() {
     private fun validateTabList(tabList: List<TabInfo>, vararg tabIds: Int) {
         val expectedTabIdList = tabIds.map { it.toString() }
         val actualTabIdList = tabList.map { it.text }
-        Assertions.assertIterableEquals(expectedTabIdList, actualTabIdList)
+        assertEquals(expectedTabIdList, actualTabIdList)
     }
 
     private fun getTabComponent(window: EditorWindow): JBEditorTabs? {


### PR DESCRIPTION
## Summary
- support moving tabs directly to the first or last position
- register MoveTabToStart and MoveTabToEnd actions without default shortcuts
- test new behaviours for moving tabs
- migrate tests to use IntelliJ platform test framework

## Testing
- `git pull` *(fails: no tracking information for the current branch)*
- `go-semantic-release --no-ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427ba77f8c832cbf814667410ced7e